### PR TITLE
fix(seeder): handle database connection errors gracefully (#10)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,10 @@ COPY --from=builder --chown=nestjs:nodejs /app/dist ./dist
 COPY --from=builder --chown=nestjs:nodejs /app/node_modules ./node_modules
 COPY --from=builder --chown=nestjs:nodejs /app/package.json ./
 
+# Copy entrypoint script
+COPY --chown=nestjs:nodejs docker-entrypoint.sh ./
+RUN chmod +x docker-entrypoint.sh
+
 # Switch to non-root user
 USER nestjs
 
@@ -52,5 +56,5 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD node -e "require('http').get('http://localhost:3000/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1))" || exit 1
 
-# Start the application
-CMD ["node", "dist/src/main.js"]
+# Run migrations and start the application
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -e
+
+echo "🚀 Starting fin-flow-api..."
+
+# Run migrations if not skipped
+if [ "$SKIP_MIGRATIONS" != "true" ]; then
+    echo "📦 Running database migrations..."
+    node -e "
+        const config = require('./dist/src/config/mikro-orm.config.js');
+        const { MikroORM } = require('@mikro-orm/postgresql');
+        
+        (async () => {
+            try {
+                const orm = await MikroORM.init(config.default);
+                const migrator = orm.getMigrator();
+                const pending = await migrator.getPendingMigrations();
+                
+                if (pending.length > 0) {
+                    console.log('Pending migrations:', pending.map(m => m.name).join(', '));
+                    await migrator.up();
+                    console.log('✅ Migrations completed successfully');
+                } else {
+                    console.log('✅ No pending migrations');
+                }
+                
+                await orm.close();
+            } catch (error) {
+                console.error('❌ Migration failed:', error.message);
+                // Don't exit - let the app try to start anyway
+                // This allows for cases where DB is temporarily unavailable
+                if (process.env.REQUIRE_MIGRATIONS === 'true') {
+                    process.exit(1);
+                }
+            }
+        })();
+    "
+fi
+
+echo "🎯 Starting NestJS application..."
+exec node dist/src/main.js

--- a/src/modules/subscription-templates/infrastructure/seeders/global-templates.seeder.ts
+++ b/src/modules/subscription-templates/infrastructure/seeders/global-templates.seeder.ts
@@ -20,7 +20,25 @@ export class GlobalTemplatesSeeder implements OnModuleInit {
       this.logger.log('GlobalTemplatesSeeder: skipped in test environment');
       return;
     }
-    await this.seed();
+
+    // Allow skipping seeding via environment variable (useful for debugging deployments)
+    if (process.env.SKIP_SEEDING === 'true') {
+      this.logger.log(
+        'GlobalTemplatesSeeder: skipped via SKIP_SEEDING env var',
+      );
+      return;
+    }
+
+    try {
+      await this.seed();
+    } catch (error) {
+      // Log error but don't crash the app - seeding is not critical for app startup
+      // The app can function without global templates, they can be seeded later
+      this.logger.error(
+        `GlobalTemplatesSeeder: failed to seed global templates. ` +
+          `This is non-fatal, the app will continue. Error: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   }
 
   async seed(): Promise<void> {


### PR DESCRIPTION
* fix(seeder): handle database connection errors gracefully

- Wrap seed() in try/catch to prevent app crash if DB is unavailable
- Add SKIP_SEEDING env var option for debugging deployments
- Log error but continue app startup - seeding is non-critical

* feat(docker): add automatic migrations on container startup

- Add docker-entrypoint.sh that runs migrations before starting the app
- Migrations run automatically unless SKIP_MIGRATIONS=true is set
- If migrations fail, app still tries to start (unless REQUIRE_MIGRATIONS=true)
- Shows pending migrations count and names in logs