### PR TITLE
fix(docker): use MikroORM CLI for migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,9 @@ COPY --from=builder --chown=nestjs:nodejs /app/dist ./dist
 COPY --from=builder --chown=nestjs:nodejs /app/node_modules ./node_modules
 COPY --from=builder --chown=nestjs:nodejs /app/package.json ./
 
+# Copy MikroORM config for CLI migrations (CLI looks for this in project root)
+COPY --from=builder --chown=nestjs:nodejs /app/dist/mikro-orm.config.js ./
+
 # Copy entrypoint script
 COPY --chown=nestjs:nodejs docker-entrypoint.sh ./
 RUN chmod +x docker-entrypoint.sh

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,42 +6,18 @@ echo "🚀 Starting fin-flow-api..."
 # Run migrations if not skipped
 if [ "$SKIP_MIGRATIONS" != "true" ]; then
     echo "📦 Running database migrations..."
-    node -e "
-        const config = require('./dist/src/config/mikro-orm.config.js');
-        const { MikroORM } = require('@mikro-orm/postgresql');
-        const { Migrator } = require('@mikro-orm/migrations');
-        
-        (async () => {
-            try {
-                const orm = await MikroORM.init(config.default);
-                const migrator = new Migrator(orm.em);
-                await migrator.init(orm);
-                
-                // Get executed migrations count
-                const storage = migrator.getStorage();
-                const executed = await storage.getExecutedMigrations();
-                console.log('Already executed:', executed.length, 'migrations');
-                
-                // Run any pending migrations
-                const result = await migrator.runMigrations();
-                
-                if (result.length > 0) {
-                    console.log('✅ Executed', result.length, 'new migration(s):', result.map(m => m.name).join(', '));
-                } else {
-                    console.log('✅ No pending migrations');
-                }
-                
-                await orm.close();
-            } catch (error) {
-                console.error('❌ Migration failed:', error.message);
-                // Don't exit - let the app try to start anyway
-                // This allows for cases where DB is temporarily unavailable
-                if (process.env.REQUIRE_MIGRATIONS === 'true') {
-                    process.exit(1);
-                }
-            }
-        })();
-    "
+    
+    # Use MikroORM CLI directly - it handles the module format correctly
+    if npx mikro-orm migration:up 2>&1; then
+        echo "✅ Migrations completed successfully"
+    else
+        echo "❌ Migration failed"
+        # Don't exit - let the app try to start anyway
+        # This allows for cases where DB is temporarily unavailable
+        if [ "$REQUIRE_MIGRATIONS" = "true" ]; then
+            exit 1
+        fi
+    fi
 fi
 
 echo "🎯 Starting NestJS application..."

--- a/src/seeders/dev-data.seeder.ts
+++ b/src/seeders/dev-data.seeder.ts
@@ -20,7 +20,27 @@ export class DevDataSeeder implements OnModuleInit {
   constructor(private readonly em: EntityManager) {}
 
   async onModuleInit(): Promise<void> {
-    await this.seed();
+    // Only run in development environment
+    if (process.env.NODE_ENV === 'production') {
+      this.logger.log('DevDataSeeder: skipped in production environment');
+      return;
+    }
+
+    // Skip in test environment - tests manage their own data
+    if (process.env.NODE_ENV === 'test') {
+      this.logger.log('DevDataSeeder: skipped in test environment');
+      return;
+    }
+
+    try {
+      await this.seed();
+    } catch (error) {
+      // Log error but don't crash the app - dev seeding is not critical
+      this.logger.error(
+        `DevDataSeeder: failed to seed dev data. This is non-fatal, the app will continue. ` +
+          `Error: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   }
 
   async seed(): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes database migrations not running on container startup.

## Problem

The manual `Migrator` instantiation wasn't finding migration files due to CommonJS/ESM module format issues in MikroORM v7. The log showed:
```
Already executed: 0 migrations
✅ No pending migrations
```
But the tables didn't exist, causing the seeders to crash.

## Solution

1. **Use MikroORM CLI instead of manual Migrator** - `npx mikro-orm migration:up` handles module format correctly
2. **Copy `mikro-orm.config.js` to container root** - CLI needs this file in project root
3. **Skip DevDataSeeder in production** - It was crashing trying to seed on empty tables

## Changes

- `docker-entrypoint.sh`: Replaced Node.js script with `npx mikro-orm migration:up`
- `Dockerfile`: Copy `mikro-orm.config.js` to project root for CLI
- `src/seeders/dev-data.seeder.ts`: Skip in production, handle errors gracefully