### PR TITLE
fix(preferences): declare ManyToOne relation for userId in schema

### DIFF
--- a/src/modules/preferences/infrastructure/persistence/user-preferences.schema.ts
+++ b/src/modules/preferences/infrastructure/persistence/user-preferences.schema.ts
@@ -7,6 +7,7 @@ export const UserPreferencesSchema = new EntitySchema<UserPreferences>({
   tableName: 'user_preferences',
   properties: {
     id: { type: 'uuid', primary: true },
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     userId: {
       kind: 'm:1',
       entity: () => User,

--- a/src/modules/preferences/infrastructure/persistence/user-preferences.schema.ts
+++ b/src/modules/preferences/infrastructure/persistence/user-preferences.schema.ts
@@ -1,4 +1,5 @@
 import { EntitySchema } from '@mikro-orm/core';
+import { User } from '../../../auth/domain/entities/user.entity';
 import { UserPreferences } from '../../domain/entities/user-preferences.entity';
 
 export const UserPreferencesSchema = new EntitySchema<UserPreferences>({
@@ -6,7 +7,13 @@ export const UserPreferencesSchema = new EntitySchema<UserPreferences>({
   tableName: 'user_preferences',
   properties: {
     id: { type: 'uuid', primary: true },
-    userId: { type: 'uuid', fieldName: 'user_id', unique: true },
+    userId: {
+      kind: 'm:1',
+      entity: () => User,
+      fieldName: 'user_id',
+      unique: true,
+      mapToPk: true,
+    } as any,
     currency: { type: 'string', length: 3 },
     dateFormat: { type: 'string', length: 10, fieldName: 'date_format' },
     language: { type: 'string', length: 2 },


### PR DESCRIPTION
Closes #20

## Type of change

- [x] Bug fix

## Summary

- `UserPreferencesSchema` declared `userId` as a plain `uuid` field — MikroORM had no knowledge of the FK dependency with `users`, causing a FK violation on user registration
- Changed `userId` to a `ManyToOne` relation with `mapToPk: true` so MikroORM resolves the correct INSERT order (users first, then preferences) during flush
- Zero changes to the domain entity — `UserPreferences.userId` remains `string`

## Changes

| File | Change |
|------|--------|
| `src/modules/preferences/infrastructure/persistence/user-preferences.schema.ts` | Declare `userId` as `ManyToOne` relation with `mapToPk: true` |

## Test Plan

- [x] TypeScript compiles without errors (`pnpm tsc --noEmit`)
- [x] Reproduced in production logs — FK violation on register endpoint
- [x] Fix resolves the INSERT ordering issue at the ORM schema level